### PR TITLE
refactor testhttp package to make it more user frendly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ notifications:
 # build and immediately stop. It's sorta like having set -e enabled in bash.
 # Make sure golangci-lint is vendored.
 before_script:
-  - go install github.com/golangci/golangci-lint/cmd/golangci-lint
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin
 
 # script always runs to completion (set +e). If we have linter issues AND a
 # failing test, we want to see both. Configure golangci-lint with a

--- a/testhttp/requests_test.go
+++ b/testhttp/requests_test.go
@@ -5,10 +5,13 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+
+	"github.com/go-bdd/gobdd"
 )
 
 func TestValidMethods(t *testing.T) {
-	handler := Build(testHandler{})
+	s := gobdd.NewSuite(t, gobdd.NewSuiteOptions())
+	handler := Build(s, testHandler{})
 	methods := []string{"Get", "Post", "Trace", "Options", "Head", "Connect", "Patch", "Put", "Delete"}
 
 	for _, method := range methods {

--- a/testhttp/setup.go
+++ b/testhttp/setup.go
@@ -1,7 +1,53 @@
 package testhttp
 
-func Build(h httpHandler) TestHTTP {
-	return TestHTTP{
+import (
+	"fmt"
+
+	"github.com/go-bdd/gobdd/context"
+	"github.com/go-bdd/gobdd/step"
+)
+
+type addStepper interface {
+	AddStep(step interface{}, f step.Func) error
+}
+
+type testHTTPMethods struct {
+	tHTTP TestHTTP
+}
+
+type httpResponse struct{}
+
+func Build(addStep addStepper, h httpHandler) TestHTTP {
+	thhtp := TestHTTP{
 		handler: h,
 	}
+
+	testHTTP := testHTTPMethods{tHTTP: thhtp}
+
+	_ = addStep.AddStep(`^I make a (GET|POST|PUT|DELETE|OPTIONS) request to "([^"]*)"$`, testHTTP.makeRequest)
+	_ = addStep.AddStep(`^the response code equals (\d+)$`, testHTTP.statusCodeEquals)
+
+	return thhtp
+}
+
+func (t testHTTPMethods) makeRequest(ctx context.Context) error {
+	method := ctx.GetStringParam(0)
+	url := ctx.GetStringParam(1)
+	resp, err := t.tHTTP.Request(method, url, nil)
+	if err != nil {
+		return err
+	}
+
+	ctx.Set(httpResponse{}, resp)
+	return nil
+}
+
+func (t testHTTPMethods) statusCodeEquals(ctx context.Context) error {
+	expectedStatus := ctx.GetIntParam(0)
+	resp := ctx.Get(httpResponse{}).(Response)
+
+	if expectedStatus != resp.Code {
+		return fmt.Errorf("expected status code: %d but %d given", expectedStatus, resp.Code)
+	}
+	return nil
 }

--- a/testhttp_test.go
+++ b/testhttp_test.go
@@ -1,19 +1,11 @@
 package gobdd
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 
-	"github.com/go-bdd/gobdd/context"
 	"github.com/go-bdd/gobdd/testhttp"
 )
-
-type httpResponse struct{}
-
-type testHTTPMethods struct {
-	tHTTP testhttp.TestHTTP
-}
 
 func TestHTTP(t *testing.T) {
 	s := NewSuite(t, NewSuiteOptions().WithFeaturesPath("features/http.feature"))
@@ -22,34 +14,7 @@ func TestHTTP(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	tHTTP := testHTTPMethods{
-		tHTTP: testhttp.Build(router),
-	}
-
-	_ = s.AddStep(`^I make a (GET|POST|PUT|DELETE|OPTIONS) request to "([^"]*)"$`, tHTTP.makeRequest)
-	_ = s.AddStep(`^the response code equals (\d+)$`, tHTTP.statusCodeEquals)
+	testhttp.Build(s, router)
 
 	s.Run()
-}
-
-func (t testHTTPMethods) makeRequest(ctx context.Context) error {
-	method := ctx.GetStringParam(0)
-	url := ctx.GetStringParam(1)
-	resp, err := t.tHTTP.Request(method, url, nil)
-	if err != nil {
-		return err
-	}
-
-	ctx.Set(httpResponse{}, resp)
-	return nil
-}
-
-func (t testHTTPMethods) statusCodeEquals(ctx context.Context) error {
-	expectedStatus := ctx.GetIntParam(0)
-	resp := ctx.Get(httpResponse{}).(testhttp.Response)
-
-	if expectedStatus != resp.Code {
-		return fmt.Errorf("expected status code: %d but %d given", expectedStatus, resp.Code)
-	}
-	return nil
 }


### PR DESCRIPTION
While playing with the testhttp package I noticed that predefined steps would be very helpfull. Now, when the testhttp package is used it defines two additional steps for you:

```go
_ = addStep.AddStep(`^I make a (GET|POST|PUT|DELETE|OPTIONS) request to "([^"]*)"$`, testHTTP.makeRequest)
_ = addStep.AddStep(`^the response code equals (\d+)$`, testHTTP.statusCodeEquals)
```

In the future - I'll add more of them :) 