### PR TITLE
Add more predefined steps to HTTP testing package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,10 @@ before_script:
 script:
   - golangci-lint run       # run a bunch of code checkers/linters in parallel
   - go test -v -race ./...  # Run all the tests with the race detector enabled
+
+after_success:
   - go get github.com/philwinder/gocoverage
   - go get github.com/mattn/goveralls
   - gocoverage
   - goveralls -coverprofile=profile.cov -repotoken=$COVERALLS_TOKEN
   - go test -race -coverprofile=coverage.txt -covermode=atomic
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)

--- a/features/http.feature
+++ b/features/http.feature
@@ -5,3 +5,7 @@ Feature: HTTP requests
   Scenario: not existing URI
     When I make a GET request to "/not-exists"
     Then the response code equals 404
+  Scenario: testing JSON validation
+    When I make a GET request to "/json"
+    Then the response contains a valid JSON
+    And the response is "{"valid": "json"}"

--- a/gobdd.go
+++ b/gobdd.go
@@ -329,7 +329,7 @@ func (s *Suite) runStep(ctx context.Context, reporter reporter.Reporter, step *g
 	err = def.f(ctx)
 	if err != nil {
 		reporter.FailedStep(step, err)
-		s.t.Fail()
+		s.t.Error(err)
 	} else {
 		reporter.SucceededStep(step)
 	}

--- a/testhttp/requests_test.go
+++ b/testhttp/requests_test.go
@@ -35,7 +35,9 @@ func TestInvalidMethod(t *testing.T) {
 }
 
 type testHandler struct {
+	body []byte
 }
 
 func (h testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	_, _ = w.Write(h.body)
 }

--- a/testhttp_test.go
+++ b/testhttp_test.go
@@ -14,6 +14,11 @@ func TestHTTP(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
+	router.HandleFunc("/json", func(w http.ResponseWriter, req *http.Request) {
+		_, _ = w.Write([]byte(`{"valid": "json"}`))
+		w.WriteHeader(http.StatusOK)
+	})
+
 	testhttp.Build(s, router)
 
 	s.Run()


### PR DESCRIPTION
In this PR I extend what started creating in https://github.com/go-bdd/gobdd/pull/31.

I added two pre defines steps:

* `the response contains a valid JSON`
* `the response is "(.*)"`

These steps should improve the usability of the package and cover most cases.