### PR TITLE
use built in http.Request objects

### DIFF
--- a/testhttp/requests.go
+++ b/testhttp/requests.go
@@ -1,7 +1,6 @@
 package testhttp
 
 import (
-	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -22,47 +21,51 @@ type TestHTTP struct {
 }
 
 func (thhtp TestHTTP) Trace(url string, body io.Reader) (Response, error) {
-	return thhtp.Request(http.MethodTrace, url, body)
+	req, _ := http.NewRequest(http.MethodTrace, url, body)
+	return thhtp.MakeRequest(req)
 }
 
 func (thhtp TestHTTP) Options(url string, body io.Reader) (Response, error) {
-	return thhtp.Request(http.MethodOptions, url, body)
+	req, _ := http.NewRequest(http.MethodOptions, url, body)
+	return thhtp.MakeRequest(req)
 }
 
 func (thhtp TestHTTP) Head(url string, body io.Reader) (Response, error) {
-	return thhtp.Request(http.MethodHead, url, body)
+	req, _ := http.NewRequest(http.MethodHead, url, body)
+	return thhtp.MakeRequest(req)
 }
 
 func (thhtp TestHTTP) Connect(url string, body io.Reader) (Response, error) {
-	return thhtp.Request(http.MethodConnect, url, body)
+	req, _ := http.NewRequest(http.MethodConnect, url, body)
+	return thhtp.MakeRequest(req)
 }
 
 func (thhtp TestHTTP) Patch(url string, body io.Reader) (Response, error) {
-	return thhtp.Request(http.MethodPatch, url, body)
+	req, _ := http.NewRequest(http.MethodPatch, url, body)
+	return thhtp.MakeRequest(req)
 }
 
 func (thhtp TestHTTP) Post(url string, body io.Reader) (Response, error) {
-	return thhtp.Request(http.MethodPost, url, body)
+	req, _ := http.NewRequest(http.MethodPost, url, body)
+	return thhtp.MakeRequest(req)
 }
 
 func (thhtp TestHTTP) Put(url string, body io.Reader) (Response, error) {
-	return thhtp.Request(http.MethodPut, url, body)
+	req, _ := http.NewRequest(http.MethodPut, url, body)
+	return thhtp.MakeRequest(req)
 }
 
 func (thhtp TestHTTP) Delete(url string, body io.Reader) (Response, error) {
-	return thhtp.Request(http.MethodDelete, url, body)
+	req, _ := http.NewRequest(http.MethodDelete, url, body)
+	return thhtp.MakeRequest(req)
 }
 
 func (thhtp TestHTTP) Get(url string, body io.Reader) (Response, error) {
-	return thhtp.Request(http.MethodGet, url, body)
+	req, _ := http.NewRequest(http.MethodGet, url, body)
+	return thhtp.MakeRequest(req)
 }
 
-func (thhtp TestHTTP) Request(method, url string, body io.Reader) (Response, error) {
-	req, err := http.NewRequest(method, url, body)
-	if err != nil {
-		return Response{}, errors.New("invalid HTTP method type")
-	}
-
+func (thhtp TestHTTP) MakeRequest(req *http.Request) (Response, error) {
 	rr := httptest.NewRecorder()
 	thhtp.handler.ServeHTTP(rr, req)
 

--- a/testhttp/requests_test.go
+++ b/testhttp/requests_test.go
@@ -25,15 +25,6 @@ func TestValidMethods(t *testing.T) {
 	}
 }
 
-func TestInvalidMethod(t *testing.T) {
-	method := "NOT EXISTS"
-	handler := TestHTTP{}
-	_, err := handler.Request(method, "", nil)
-	if err == nil {
-		t.Error("the handler should not allow for invalid HTTP methods")
-	}
-}
-
 type testHandler struct {
 	body []byte
 }

--- a/testhttp/setup.go
+++ b/testhttp/setup.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 
 	"github.com/go-bdd/gobdd/context"
 	"github.com/go-bdd/gobdd/step"
@@ -71,7 +72,12 @@ func (t testHTTPMethods) validJSON(ctx context.Context) error {
 func (t testHTTPMethods) makeRequest(ctx context.Context) error {
 	method := ctx.GetStringParam(0)
 	url := ctx.GetStringParam(1)
-	resp, err := t.tHTTP.Request(method, url, nil)
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := t.tHTTP.MakeRequest(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I changed two things here:
 * renamed the `Request` function to `MakeRequest` - better description of what it does
* use built-in `http.Request` structs in the testhttp package