### PR TITLE
Fix step failure message

### DIFF
--- a/gobdd_test.go
+++ b/gobdd_test.go
@@ -87,13 +87,13 @@ func TestInvalidFunctionSignature(t *testing.T) {
 
 func TestFailureOutput(t *testing.T) {
 	testCases := []struct {
-		name     string
-		f        interface{}
-		expected []string
+		name           string
+		f              interface{}
+		expectedErrors []string
 	}{
-		{name: "passes", f: pass, expected: nil},
-		{name: "returns error", f: failure, expected: []string{"Test text: the step failed"}},
-		{name: "step panics", f: panics, expected: []string{"the step panicked"}},
+		{name: "passes", f: pass, expectedErrors: nil},
+		{name: "returns error", f: failure, expectedErrors: []string{"Test text: the step failed"}},
+		{name: "step panics", f: panics, expectedErrors: []string{"the step panicked"}},
 	}
 
 	for _, testCase := range testCases {
@@ -103,7 +103,7 @@ func TestFailureOutput(t *testing.T) {
 
 			tester := &mockTester{}
 			def.run(context.New(), tester, step, nil)
-			err := assert.Equals(testCase.expected, tester.errors)
+			err := assert.Equals(testCase.expectedErrors, tester.errors)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Fixes #66

When a step failed, the step's Kind was being passed in as the format param. This wasn't a valid format and so an Printf error was being printed out resulting in a garbled error. Added a proper format param in front of the Kind. Also extracted the function that runs each step so it could be unit tested properly