### PR TITLE
Better testify support

### DIFF
--- a/gobdd.go
+++ b/gobdd.go
@@ -104,12 +104,14 @@ type StepTest interface {
 	Fatalf(string, ...interface{})
 	Errorf(string, ...interface{})
 	Error(...interface{})
+
+	Fail()
+	FailNow()
 }
 
 type TestingT interface {
 	StepTest
 	Parallel()
-	Fail()
 	Run(name string, f func(t *testing.T)) bool
 }
 

--- a/gobdd_test.go
+++ b/gobdd_test.go
@@ -258,6 +258,9 @@ func (m *mockTester) Parallel() {
 func (m *mockTester) Fail() {
 }
 
+func (m *mockTester) FailNow() {
+}
+
 func (m *mockTester) Run(_ string, _ func(t *testing.T)) bool {
 	return true
 }


### PR DESCRIPTION
Testify's require package has a `TestingT` like this:

```
// TestingT is an interface wrapper around *testing.T
type TestingT interface {
	Errorf(format string, args ...interface{})
	FailNow()
}
```

This PR adds support for using the require package. (The assert package works fine)