### PR TITLE
Do not discard log output

### DIFF
--- a/gobdd.go
+++ b/gobdd.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"

--- a/gobdd.go
+++ b/gobdd.go
@@ -308,8 +308,6 @@ func (s *Suite) runFeature(feature *msgs.GherkinDocument_Feature) error {
 		}
 	}
 
-	log.SetOutput(ioutil.Discard)
-
 	hasErrors := false
 
 	s.t.Run(fmt.Sprintf("%s %s", strings.TrimSpace(feature.Keyword), feature.Name), func(t *testing.T) {


### PR DESCRIPTION
There might be a good reason behind this that I'm not aware of, but this has been tripping me up because our things under test have a debug mode that logs very useful information to determine the cause of the test failure, which just wouldn't be printed when using gobdd.

I have a workaround in place to reset the log output to `stderr` in a `WithBeforeScenario` step, but that'd be awesome to just have it working and avoid surprises and debugging time in the future 😅.

Thanks for considering this