### PR TITLE
Use both feature and scenario tags in skipScenario

### DIFF
--- a/features/filter_tags_negative.feature
+++ b/features/filter_tags_negative.feature
@@ -1,0 +1,3 @@
+Feature: do not run this
+  Scenario: the scenario should not executed
+    Then fail the test

--- a/features/filter_tags_positive.feature
+++ b/features/filter_tags_positive.feature
@@ -1,0 +1,4 @@
+@run-this
+Feature: run this
+  Scenario: the scenario should executed
+    Then the test should pass

--- a/gobdd.go
+++ b/gobdd.go
@@ -321,7 +321,7 @@ func (s *Suite) runFeature(feature *msgs.GherkinDocument_Feature) error {
 				continue
 			}
 
-			if s.skipScenario(scenario.GetTags()) {
+			if s.skipScenario(append(feature.GetTags(), scenario.GetTags()...)) {
 				t.Log(fmt.Sprintf("Skipping scenario %s", scenario.Name))
 				continue
 			}

--- a/gobdd_test.go
+++ b/gobdd_test.go
@@ -128,7 +128,7 @@ func TestFilterFeatureWithTags(t *testing.T) {
 	suite.AddStep(`fail the test`, fail)
 
 	suite.Run()
-	
+
 	if err := assert.Equals(true, c); err != nil {
 		t.Error(err)
 	}

--- a/gobdd_test.go
+++ b/gobdd_test.go
@@ -118,6 +118,22 @@ func TestTags(t *testing.T) {
 	suite.Run()
 }
 
+func TestFilterFeatureWithTags(t *testing.T) {
+	suite := NewSuite(t, WithFeaturesPath("features/filter_tags_*.feature"), WithTags([]string{"@run-this"}))
+	c := false
+
+	suite.AddStep(`the test should pass`, func(_ StepTest, _ Context) {
+		c = true
+	})
+	suite.AddStep(`fail the test`, fail)
+
+	suite.Run()
+	
+	if err := assert.Equals(true, c); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestWithAfterScenario(t *testing.T) {
 	c := false
 	suite := NewSuite(t, WithFeaturesPath("features/empty.feature"), WithAfterScenario(func(ctx Context) {
@@ -183,6 +199,7 @@ func TestIgnorFeatureWithTags(t *testing.T) {
 	suite.AddStep(`fail the test`, fail)
 	suite.Run()
 }
+
 func TestInvalidFunctionSignature(t *testing.T) {
 	testCases := map[string]struct {
 		f interface{}


### PR DESCRIPTION
Currently the feature tags are not taken into account when determining if a scenario should be executed or not.

This should allow positive filtering which is different from skip.