### PR TITLE
Fixing typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Inside `features` folder create your scenarios. Here is an example:
 Feature: math operations
   Scenario: add two digits
     When I add 1 and 2
-    Then I the result should equal 3
+    Then the result should equal 3
 ```
 
 Add a new test `main_test.go`:
@@ -54,7 +54,7 @@ func check(t gobdd.StepTest, ctx gobdd.Context, sum int) {
 func TestScenarios(t *testing.T) {
 	suite := gobdd.NewSuite(t)
 	suite.AddStep(`I add (\d+) and (\d+)`, add)
-	suite.AddStep(`I the result should equal (\d+)`, check)
+	suite.AddStep(`the result should equal (\d+)`, check)
 	suite.Run()
 }
 ```

--- a/docs/quick-start.markdown
+++ b/docs/quick-start.markdown
@@ -33,7 +33,7 @@ func check(t gobdd.StepTest, ctx gobdd.Context, sum int) {
 func TestScenarios(t *testing.T) {
 	suite := NewSuite(t)
 	suite.AddStep(`I add (\d+) and (\d+)`, add)
-	suite.AddStep(`I the result should equal (\d+)`, check)
+	suite.AddStep(`the result should equal (\d+)`, check)
 	suite.Run()
 }
 ```
@@ -44,7 +44,7 @@ Inside `features` folder create your scenarios. Here is an example:
 Feature: math operations
   Scenario: add two digits
     When I add 1 and 2
-    Then I the result should equal 3
+    Then the result should equal 3
 ```
 
 and run tests


### PR DESCRIPTION
Hi, I've been enjoying using this library. I noticed a typo in the documentation and figured I'd make a quick PR to fix it.