### PR TITLE
feat: allow multiple pattern in WithFeaturesFS

### DIFF
--- a/docs/suite-options.md
+++ b/docs/suite-options.md
@@ -9,7 +9,7 @@ The suite can be confiugred using one of these functions:
 
 * `RunInParallel()` - enables running steps in parallel. It uses the stanard `T.Parallel` function.
 * `WithFeaturesPath(path string)` - configures the path where GoBDD should look for features. The default value is `features/*.feature`.
-* `WithFeaturesFS(fs fs.FS, path string)` - configures the filesystem and a path (glob pattern) where GoBDD should look for features.
+* `WithFeaturesFS(fs fs.FS, patterns ...string)` - configures the filesystem and glob patterns where GoBDD should look for features.
 * `WithTags(tags ...string)` - configures which tags should be run. Every tag has to start with `@`.
 * `WithBeforeScenario(f func())` - this function `f` will be called before every scenario.
 * `WithAfterScenario(f func())` - this funcion `f` will be called after every scenario.

--- a/gobdd_go1_16_test.go
+++ b/gobdd_go1_16_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWithFeaturesFS(t *testing.T) {
-	suite := NewSuite(t, WithFeaturesFS(featuresFS, "example.feature"))
+	suite := NewSuite(t, WithFeaturesFS(featuresFS, "example.feature", "example_rule.feature"))
 	compiled := regexp.MustCompile(`I add (\d+) and (\d+)`)
 	suite.AddRegexStep(compiled, add)
 	compiled = regexp.MustCompile(`the result should equal (\d+)`)


### PR DESCRIPTION
With a file system defined as 
```go
//go:embed *.feature */*.feature
var features embed.FS
```
it is not currently possible to select feature from both the root directory and a sub directory. 
After the change, it can be accomplished with `gobdd.WithFeaturesFS(features.Features.FS, "*.feature, "*/*.feature")`